### PR TITLE
Add sample keyword

### DIFF
--- a/sqlsonnet/sql.pest
+++ b/sqlsonnet/sql.pest
@@ -41,6 +41,7 @@ FROM     = { ^"from" }
 GROUP_BY = { ^"group by" }
 ORDER_BY = { ^"order by" }
 LIMIT    = { ^"limit" }
+SAMPLE   = { ^"sample" }
 WHERE    = { ^"where" }
 HAVING   = { ^"having" }
 USING    = { ^"using" }
@@ -48,7 +49,7 @@ ON       = { ^"on" }
 SELECT   = { ^"select" }
 SETTINGS   = { ^"settings" }
 JOIN     = { ^"inner "? ~ ^"join" }
-KEYWORD  = { ASC | DESC | AS | SELECT | FROM | GROUP_BY | ORDER_BY | WHERE | LIMIT | JOIN | USING | HAVING | ON | SETTINGS }
+KEYWORD  = { ASC | DESC | AS | SELECT | FROM | GROUP_BY | ORDER_BY | WHERE | LIMIT | SAMPLE | JOIN | USING | HAVING | ON | SETTINGS }
 
 simple_identifier = @{ (ASCII_ALPHA+ ~ (ASCII_ALPHANUMERIC | "_")*) | "*" }
 identifier        = @{ !KEYWORD ~ (simple_identifier ~ ".")? ~ simple_identifier }
@@ -77,12 +78,14 @@ order_by    = { ORDER_BY ~ order_exprs }
 
 limit = { LIMIT ~ #limit = number }
 
+sample = { SAMPLE ~ #sample = number }
+
 settings = { SETTINGS ~ exprs }
 
 fields = { exprs }
 
 select = {
-    SELECT ~ fields ~ (FROM ~ table_or_subquery)? ~ join* ~ where? ~ group_by? ~ having? ~ order_by? ~ limit? ~ settings? ~ ";"?
+    SELECT ~ fields ~ (FROM ~ table_or_subquery)? ~ join* ~ where? ~ group_by? ~ having? ~ order_by? ~ limit? ~ sample? ~ settings? ~ ";"?
 }
 
 query   = { SOI ~ select ~ EOI }

--- a/sqlsonnet/src/from_sql.rs
+++ b/sqlsonnet/src/from_sql.rs
@@ -255,6 +255,16 @@ impl FromParsed for queries::select::Query {
                             .unwrap(),
                     );
                 }
+                Rule::sample => {
+                    query.sample = Some(
+                        p.into_inner()
+                            .find_first_tagged("sample")
+                            .unwrap()
+                            .as_str()
+                            .parse()
+                            .unwrap(),
+                    )
+                }
                 Rule::order_by => {
                     query.order_by = FromParsed::parse(p.into_inner().nth(1).unwrap())?;
                 }

--- a/sqlsonnet/src/queries.rs
+++ b/sqlsonnet/src/queries.rs
@@ -322,6 +322,8 @@ pub mod select {
         // TODO: Error if `limit` is not set
         // TODO: Support in from_sql
         pub limit_by: Option<ExprList>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub sample: Option<usize>,
         #[serde(default, skip_serializing_if = "ExprList::is_empty")]
         pub settings: ExprList,
     }

--- a/sqlsonnet/src/to_sql.rs
+++ b/sqlsonnet/src/to_sql.rs
@@ -293,6 +293,9 @@ impl ToSql for select::Query {
                 exprs.to_sql(&mut f.indented())?;
             }
         }
+        if let Some(sample) = &self.sample {
+            write!(f, "\nSAMPLE {}", sample)?;
+        }
         if !self.settings.is_empty() {
             write!(f, "\nSETTINGS ")?;
             self.settings.to_sql(f)?;

--- a/sqlsonnet/tests/data/example.jsonnet
+++ b/sqlsonnet/tests/data/example.jsonnet
@@ -50,6 +50,8 @@
       orderBy: ['col1', { expr: 'col2', order: 'desc' }, { expr: 'col3', order: 'asc' }],
       // Integer (optional)
       limit: 100,
+      // Integer (optional)
+      sample: 100,
       // List of expressions (optional)
       settings: ['join_algorithm="parallel_hash"'],
     },

--- a/sqlsonnet/tests/data/example.sql
+++ b/sqlsonnet/tests/data/example.sql
@@ -29,6 +29,7 @@ ORDER BY
   col2 DESC,
   col3
 LIMIT 100
+SAMPLE 100
 SETTINGS join_algorithm="parallel_hash"
 ;
 SELECT


### PR DESCRIPTION
SAMPLE can use both an integer (number of elements) and a float (fraction of the table), but I have implemented only the integer one. 
https://clickhouse.com/docs/en/sql-reference/statements/select/sample